### PR TITLE
Testing the new MIPS-9.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+# Igonere generated toolchains
+*-tools
+build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,73 @@
+
+build_path = build
+
+.DEFAULT_GOAL := riscv32_9.3
+
+mips-4.9_patched:
+	mkdir -p $(build_path)/$@
+	cp -f ./mips/build_mips_toolchain_4_9_patched $(build_path)/$@
+	cp -f ./env.sh $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_mips_toolchain_4_9_patched
+	cd $(build_path)/$@ && ./build_mips_toolchain_4_9_patched
+
+mips-9.3_patched:
+	mkdir -p $(build_path)/$@
+	cp -f ./mips/build_mips_toolchain_9_3_patched $(build_path)/$@
+	cp -f ./env.sh $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_mips_toolchain_9_3_patched
+	cd $(build_path)/$@ && ./build_mips_toolchain_9_3_patched
+
+mips-9.3:
+	mkdir -p $(build_path)/$@
+	cp -f ./mips/build_mips_toolchain_9_3 $(build_path)/$@
+	cp -f ./env.sh $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_mips_toolchain_9_3
+	cd $(build_path)/$@ && ./build_mips_toolchain_9_3
+
+avr-9.4:
+	mkdir -p $(build_path)/$@
+	cp -f ./avr/build_avr_toolchain_9_4 $(build_path)/$@
+	cp -f ./env.sh $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_avr_toolchain_9_4
+	cd $(build_path)/$@ && ./build_avr_toolchain_9_4
+
+riscv64_9.3:
+	mkdir -p $(build_path)/$@
+	cp -f ./riscv/build_riscv64_toolchain_9_3 $(build_path)/$@
+	cp -f ./env.sh $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_riscv64_toolchain_9_3
+	cd $(build_path)/$@ && ./build_riscv64_toolchain_9_3
+
+riscv32_9.3:
+	mkdir -p $(build_path)/$@
+	cp -f ./riscv/build_riscv32_toolchain_9_3 $(build_path)/$@
+	cp -f ./env.sh $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_riscv32_toolchain_9_3
+	cd $(build_path)/$@ && ./build_riscv32_toolchain_9_3
+
+arm-7.1:
+	mkdir -p $(build_path)/$@
+	cp -f ./arm/build_arm_toolchain_7_1 $(build_path)/$@
+	cp -f ./env.sh $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_arm_toolchain_7_1
+	cd $(build_path)/$@ && ./build_arm_toolchain_7_1
+
+arm-9.4:
+	mkdir -p $(build_path)/$@
+	cp -f ./arm/build_arm_toolchain_9_4 $(build_path)/$@
+	cp -f ./env.sh $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_arm_toolchain_9_4
+	cd $(build_path)/$@ && ./build_arm_toolchain_9_4
+
+all:
+	make -s mips-4.9_patched
+	make -s mips-9.3_patched
+	make -s mips-9.3
+	make -s avr-9.4
+	make -s riscv64_9.3
+	make -s riscv32_9.3
+	make -s arm-7.1
+	make -s arm-9.4
+
+cleanall:
+	rm -rf $(build_path)

--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,14 @@ arm-9.4:
 	cd $(build_path)/$@ && ./build_arm_toolchain_9_4
 
 all:
-	make -s mips-4.9_patched
-	make -s mips-9.3_patched
-	make -s mips-9.3
-	make -s avr-9.4
-	make -s riscv64_9.3
-	make -s riscv32_9.3
-	make -s arm-7.1
-	make -s arm-9.4
+	make -s mips-4.9_patched || true
+	make -s mips-9.3_patched || true
+	make -s mips-9.3 || true
+	make -s avr-9.4 || true
+	make -s riscv64_9.3 || true
+	make -s riscv32_9.3 || true
+	make -s arm-7.1 || true
+	make -s arm-9.4 || true
 
 cleanall:
 	rm -rf $(build_path)

--- a/README.md
+++ b/README.md
@@ -1,53 +1,64 @@
-# RISCV toolchain (32 bit)
+# Toolchains
 
 ---
 ### Dependencies
 
 In order to build the cross toolchain, first install all needed software packages. Additional dependencies will be downloaded and installed during the build process.
 
-	$ sudo apt-get update
-	$ sudo apt-get install flex bison libgmp3-dev libmpfr-dev autoconf texinfo build-essential libncurses5-dev
+	sudo apt-get update
+	sudo apt-get install flex \
+		bison \
+		libgmp3-dev \
+		libmpfr-dev \
+		autoconf \
+		texinfo \
+		build-essential \
+		libncurses5-dev
 
 ### Build procedure
 
-The `build_riscv_toolchain` script will automate the whole process of downloading, configuring and building basic binary tools and the compiler. All we need to do is create a working directory and copy the build script before starting the whole process.
+A simple process would be using the Makefile passing the architecture and the gcc version available as in:
 
-	$ mkdir riscv-tools && cd riscv-tools
-	$ cp ../build_riscv_toolchain .
+	make riscv32_9.3
+
+Alternativelly, the `riscv/build_riscv32_toolchain` script will automate the whole process of downloading, configuring and building basic binary tools and the compiler. All we need to do is create a working directory and copy the build script before starting the whole process.
+
+	mkdir -p riscv-tools && cd riscv-tools
+	../riscv/build_riscv32_toolchain_9_3 .
 
 We need permissions to execute the build script. If not set, change the execute bit of the script:
 
-	$ chmod +x build_riscv_toolchain
+	chmod +x build_riscv32_toolchain_9_3
 
 And now we are ready to build the cross toolchain. All software packages will be downloaded (binutils, GCC), unpacked and built. Note that we don't need root permissions to do perform this step.
 
-	$ ./build_riscv_toolchain
+	./build_riscv32_toolchain_9_3
 
-Now go do something else. The process will take between 15 minutes to 1 hour, depending on your host machine. After the process completes, you can check if the new compiler and tools were built:
+The process takes between 15 minutes to 1 hour, depending on your host machine. After the process completes, you can check if the new compiler and tools were built:
 
-	$ ls riscv32-unknown-elf/gcc-8.3.0/bin/
+	ls riscv32-unknown-elf/gcc-8.3.0/bin/
 
-If, among other files, the `riscv32-unknown-elf-gcc` executable is present then we are ok.
+If among other files, the `riscv32-unknown-elf-gcc` executable is present, the toolchain was built successfully.
 
 ### Installation
 
 The tools can be installed in any directory. Most of the time, the toolchain can be shared among users, so it makes sense to install the toolchain in the `/usr/local` directory. To install, just move the `risc32-unknown-elf` directory the its place. We need root permissions for this step. We will also create a symbolic link to the toolchain so we can keep multiple versions of the same tools in the system.
 
-	$ sudo mv riscv32-unknown-elf /usr/local
-	$ cd /usr/local/riscv32-unknown-elf
-	$ sudo ln -s gcc-8.3.0 gcc
+	sudo mv riscv32-unknown-elf /usr/local
+	cd /usr/local/riscv32-unknown-elf
+	sudo ln -s gcc-8.3.0 gcc
 
 One last step is to update the PATH environment variable. This can be done in the current terminal or we can update the `.bashrc` script found in the home directory of the current user.
 
-	$ cd ~
-	$ echo "export PATH=$PATH:/usr/local/riscv32-unknown-elf/gcc/bin" >> .bashrc
-	$ source .bashrc
+	cd ~
+	echo "export PATH=$PATH:/usr/local/riscv32-unknown-elf/gcc/bin" >> .bashrc
+	source .bashrc
 
 ### Test it!
 
 To test the toolchain,
 
-	$ riscv32-unknown-elf-gcc -v
+	riscv32-unknown-elf-gcc -v
 
 	Using built-in specs.
 	COLLECT_GCC=riscv32-unknown-elf-gcc	COLLECT_LTO_WRAPPER=/usr/local/riscv32-unknown-elf/gcc-8.3.0/bin/../libexec/gcc/riscv32-unknown-elf/8.3.0/lto-wrapper

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This is sample script to setup the environment.
+# Change the script changing the TOOLCHAIN_PATH accordingly
+
+TOOLCHAIN_PATH="./riscv32-unknown-elf/gcc-9.3.0/"
+
+export LANG="en_GB.UTF-8"
+
+# Pre-append path (binaries prefixed with arch name)
+export PATH="${TOOLCHAIN_PATH}/bin:${PATH}"
+
+# Pre-append path (binaries without prefix overlapping system settings) 
+export PATH="${TOOLCHAIN_PATH}/riscv32-unknown-elf/bin:${PATH}"
+
+# Headers
+export C_INCLUDE_PATH="${TOOLCHAIN_PATH}/include:${C_INCLUDE_PATH}"
+export CPLUS_INCLUDE_PATH="${TOOLCHAIN_PATH}/include:${CPLUS_INCLUDE_PATH}"
+
+# Libraries
+export LIBRARY_PATH="${TOOLCHAIN_PATH}/lib:${LIBRARY_PATH}"
+
+# Documentation
+prepend-path MANPATH "${BASE}/share/man"
+prepend-path INFOPATH "${BASE}/share/info"


### PR DESCRIPTION
Hi @sjohann81 

I wanted to build and check this new toolchain for MIPS using GCC 9.3 that was developed.

Initially, I was able to build `RISCV-9.3` testing the existing script on my machine. It took 30 minutes, nice.

Then I wanted to improve this repo a bit if you allow me. 

I made a Makefile to generate toolchains easier, as in, `make mips-9.3` and it has a `make all` to put all the infrastructure working with a single command if needed.

I also took a chance to rename the `INSTALL.md` to `README.md` so it will be visible from the GitHub page when someone lands on the repository website. And it also has a `.gitignore` file so git it won't bother saying the generated files are untracked. To conclude, I added a sample script to setup the environment. So it is easy to just rename this script from `env.sh` to `env-mips-9.3`, and then update the `TOOLCHAIN_PATH` inside the script allowing to load the whole environment with a simple `source env-mips-9.3` command.

By default, it generates the `build` folder with the generated files but it is also possible to build the whole thing in a different path for instance:
```
make mips-9.2 build_path=/tmp
```
