### PR TITLE
Latest fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,56 +8,56 @@ mips-4.9_patched:
 	cp -f ./mips/build_mips_toolchain_4_9_patched $(build_path)/$@
 	cp -f ./env.sh $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_mips_toolchain_4_9_patched
-	cd $(build_path)/$@ && ./build_mips_toolchain_4_9_patched | tee build.log
+	cd $(build_path)/$@ && ./build_mips_toolchain_4_9_patched 2>&1 | tee build.log
 
 mips-9.3_patched:
 	mkdir -p $(build_path)/$@
 	cp -f ./mips/build_mips_toolchain_9_3_patched $(build_path)/$@
 	cp -f ./env.sh $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_mips_toolchain_9_3_patched
-	cd $(build_path)/$@ && ./build_mips_toolchain_9_3_patched | tee build.log
+	cd $(build_path)/$@ && ./build_mips_toolchain_9_3_patched 2>&1 | tee build.log
 
 mips-9.3:
 	mkdir -p $(build_path)/$@
 	cp -f ./mips/build_mips_toolchain_9_3 $(build_path)/$@
 	cp -f ./env.sh $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_mips_toolchain_9_3
-	cd $(build_path)/$@ && ./build_mips_toolchain_9_3 | tee build.log
+	cd $(build_path)/$@ && ./build_mips_toolchain_9_3 2>&1 | tee build.log
 
 avr-9.4:
 	mkdir -p $(build_path)/$@
 	cp -f ./avr/build_avr_toolchain_9_4 $(build_path)/$@
 	cp -f ./env.sh $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_avr_toolchain_9_4
-	cd $(build_path)/$@ && ./build_avr_toolchain_9_4 | tee build.log
+	cd $(build_path)/$@ && ./build_avr_toolchain_9_4 2>&1 | tee build.log
 
 riscv64_9.3:
 	mkdir -p $(build_path)/$@
 	cp -f ./riscv/build_riscv64_toolchain_9_3 $(build_path)/$@
 	cp -f ./env.sh $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_riscv64_toolchain_9_3
-	cd $(build_path)/$@ && ./build_riscv64_toolchain_9_3 | tee build.log
+	cd $(build_path)/$@ && ./build_riscv64_toolchain_9_3 2>&1 | tee build.log
 
 riscv32_9.3:
 	mkdir -p $(build_path)/$@
 	cp -f ./riscv/build_riscv32_toolchain_9_3 $(build_path)/$@
 	cp -f ./env.sh $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_riscv32_toolchain_9_3
-	cd $(build_path)/$@ && ./build_riscv32_toolchain_9_3 | tee build.log
+	cd $(build_path)/$@ && ./build_riscv32_toolchain_9_3 2>&1 | tee build.log
 
 arm-7.1:
 	mkdir -p $(build_path)/$@
 	cp -f ./arm/build_arm_toolchain_7_1 $(build_path)/$@
 	cp -f ./env.sh $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_arm_toolchain_7_1
-	cd $(build_path)/$@ && ./build_arm_toolchain_7_1 | tee build.log
+	cd $(build_path)/$@ && ./build_arm_toolchain_7_1 2>&1 | tee build.log
 
 arm-9.4:
 	mkdir -p $(build_path)/$@
 	cp -f ./arm/build_arm_toolchain_9_4 $(build_path)/$@
 	cp -f ./env.sh $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_arm_toolchain_9_4
-	cd $(build_path)/$@ && ./build_arm_toolchain_9_4 | tee build.log
+	cd $(build_path)/$@ && ./build_arm_toolchain_9_4 2>&1 | tee build.log
 
 all:
 	make -s mips-4.9_patched || true

--- a/Makefile
+++ b/Makefile
@@ -1,63 +1,63 @@
 
 build_path = build
 
-.DEFAULT_GOAL := riscv32_9.3
-
-mips-4.9_patched:
-	mkdir -p $(build_path)/$@
-	cp -f ./mips/build_mips_toolchain_4_9_patched $(build_path)/$@
-	cp -f ./env.sh $(build_path)/$@
-	cd $(build_path)/$@ && chmod +x build_mips_toolchain_4_9_patched
-	cd $(build_path)/$@ && ./build_mips_toolchain_4_9_patched 2>&1 | tee build.log
-
-mips-9.3_patched:
-	mkdir -p $(build_path)/$@
-	cp -f ./mips/build_mips_toolchain_9_3_patched $(build_path)/$@
-	cp -f ./env.sh $(build_path)/$@
-	cd $(build_path)/$@ && chmod +x build_mips_toolchain_9_3_patched
-	cd $(build_path)/$@ && ./build_mips_toolchain_9_3_patched 2>&1 | tee build.log
-
-mips-9.3:
-	mkdir -p $(build_path)/$@
-	cp -f ./mips/build_mips_toolchain_9_3 $(build_path)/$@
-	cp -f ./env.sh $(build_path)/$@
-	cd $(build_path)/$@ && chmod +x build_mips_toolchain_9_3
-	cd $(build_path)/$@ && ./build_mips_toolchain_9_3 2>&1 | tee build.log
-
-avr-9.4:
-	mkdir -p $(build_path)/$@
-	cp -f ./avr/build_avr_toolchain_9_4 $(build_path)/$@
-	cp -f ./env.sh $(build_path)/$@
-	cd $(build_path)/$@ && chmod +x build_avr_toolchain_9_4
-	cd $(build_path)/$@ && ./build_avr_toolchain_9_4 2>&1 | tee build.log
-
-riscv64_9.3:
-	mkdir -p $(build_path)/$@
-	cp -f ./riscv/build_riscv64_toolchain_9_3 $(build_path)/$@
-	cp -f ./env.sh $(build_path)/$@
-	cd $(build_path)/$@ && chmod +x build_riscv64_toolchain_9_3
-	cd $(build_path)/$@ && ./build_riscv64_toolchain_9_3 2>&1 | tee build.log
-
-riscv32_9.3:
-	mkdir -p $(build_path)/$@
-	cp -f ./riscv/build_riscv32_toolchain_9_3 $(build_path)/$@
-	cp -f ./env.sh $(build_path)/$@
-	cd $(build_path)/$@ && chmod +x build_riscv32_toolchain_9_3
-	cd $(build_path)/$@ && ./build_riscv32_toolchain_9_3 2>&1 | tee build.log
+.DEFAULT_GOAL := all
 
 arm-7.1:
 	mkdir -p $(build_path)/$@
 	cp -f ./arm/build_arm_toolchain_7_1 $(build_path)/$@
-	cp -f ./env.sh $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_arm_toolchain_7_1
 	cd $(build_path)/$@ && ./build_arm_toolchain_7_1 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/arm-none-eabi/gcc-*/arm-none-eabi
 
 arm-9.4:
 	mkdir -p $(build_path)/$@
 	cp -f ./arm/build_arm_toolchain_9_4 $(build_path)/$@
-	cp -f ./env.sh $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_arm_toolchain_9_4
 	cd $(build_path)/$@ && ./build_arm_toolchain_9_4 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/arm-none-eabi/gcc-*/arm-none-eabi
+
+avr-9.4:
+	mkdir -p $(build_path)/$@
+	cp -f ./avr/build_avr_toolchain_9_4 $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_avr_toolchain_9_4
+	cd $(build_path)/$@ && ./build_avr_toolchain_9_4 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/avr/gcc-*/avr
+
+mips-4.9_patched:
+	mkdir -p $(build_path)/$@
+	cp -f ./mips/build_mips_toolchain_4_9_patched $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_mips_toolchain_4_9_patched
+	cd $(build_path)/$@ && ./build_mips_toolchain_4_9_patched 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/mips-elf/gcc-*/mips-elf/
+
+mips-9.3:
+	mkdir -p $(build_path)/$@
+	cp -f ./mips/build_mips_toolchain_9_3 $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_mips_toolchain_9_3
+	cd $(build_path)/$@ && ./build_mips_toolchain_9_3 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/mips-elf/gcc-*/mips-elf/
+
+mips-9.3_patched:
+	mkdir -p $(build_path)/$@
+	cp -f ./mips/build_mips_toolchain_9_3_patched $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_mips_toolchain_9_3_patched
+	cd $(build_path)/$@ && ./build_mips_toolchain_9_3_patched 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/mips-elf/gcc-*/mips-elf/
+
+riscv32_9.3:
+	mkdir -p $(build_path)/$@
+	cp -f ./riscv/build_riscv32_toolchain_9_3 $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_riscv32_toolchain_9_3
+	cd $(build_path)/$@ && ./build_riscv32_toolchain_9_3 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/riscv32-unknown-elf/gcc-*/riscv32-unknown-elf/
+
+riscv64_9.3:
+	mkdir -p $(build_path)/$@
+	cp -f ./riscv/build_riscv64_toolchain_9_3 $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_riscv64_toolchain_9_3
+	cd $(build_path)/$@ && ./build_riscv64_toolchain_9_3 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/riscv32-unknown-elf/gcc-*/riscv32-unknown-elf/
 
 all:
 	make -s mips-4.9_patched || true

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,13 @@ avr-9.4:
 	cd $(build_path)/$@ && ./build_avr_toolchain_9_4 2>&1 | tee build.log
 	cp -f ./env.sh $(build_path)/$@/avr/gcc-*/avr
 
+avr-11.2:
+	mkdir -p $(build_path)/$@
+	cp -f ./avr/build_avr_toolchain_11_2 $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_avr_toolchain_11_2
+	cd $(build_path)/$@ && ./build_avr_toolchain_11_2 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/avr/gcc-*/avr
+
 mips-4.9_patched:
 	mkdir -p $(build_path)/$@
 	cp -f ./mips/build_mips_toolchain_4_9_patched $(build_path)/$@
@@ -59,12 +66,27 @@ riscv32_9.3:
 	cd $(build_path)/$@ && ./build_riscv32_toolchain_9_3 2>&1 | tee build.log
 	cp -f ./env.sh $(build_path)/$@/riscv32-unknown-elf/gcc-*/riscv32-unknown-elf/
 
+riscv32_11.2:
+	mkdir -p $(build_path)/$@
+	cp -f ./riscv/build_riscv32_toolchain_11_2 $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_riscv32_toolchain_11_2
+	cd $(build_path)/$@ && ./build_riscv32_toolchain_11_2 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/riscv32-unknown-elf/gcc-*/riscv32-unknown-elf/
+
 riscv64_9.3:
 	mkdir -p $(build_path)/$@
 	cp -f ./riscv/build_riscv64_toolchain_9_3 $(build_path)/$@
 	cd $(build_path)/$@ && chmod +x build_riscv64_toolchain_9_3
 	cd $(build_path)/$@ && ./build_riscv64_toolchain_9_3 2>&1 | tee build.log
 	cp -f ./env.sh $(build_path)/$@/riscv32-unknown-elf/gcc-*/riscv32-unknown-elf/
+
+riscv64_11.2:
+	mkdir -p $(build_path)/$@
+	cp -f ./riscv/build_riscv32_toolchain_11_2 $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_riscv32_toolchain_11_2
+	cd $(build_path)/$@ && ./build_riscv32_toolchain_11_2 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/riscv32-unknown-elf/gcc-*/riscv32-unknown-elf/
+
 
 all:
 	make -s mips-4.9_patched || true

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,13 @@ mips-9.3_patched:
 	cd $(build_path)/$@ && ./build_mips_toolchain_9_3_patched 2>&1 | tee build.log
 	cp -f ./env.sh $(build_path)/$@/mips-elf/gcc-*/mips-elf/
 
+mips-11.2_patched:
+	mkdir -p $(build_path)/$@
+	cp -f ./mips/build_mips_toolchain_11_2_patched $(build_path)/$@
+	cd $(build_path)/$@ && chmod +x build_mips_toolchain_11_2_patched
+	cd $(build_path)/$@ && ./build_mips_toolchain_11_2_patched 2>&1 | tee build.log
+	cp -f ./env.sh $(build_path)/$@/mips-elf/gcc-*/mips-elf/
+
 riscv32_9.3:
 	mkdir -p $(build_path)/$@
 	cp -f ./riscv/build_riscv32_toolchain_9_3 $(build_path)/$@

--- a/arm/build_arm_toolchain_7_1
+++ b/arm/build_arm_toolchain_7_1
@@ -30,10 +30,10 @@ src_dir="${root_dir}/source"
 bld_dir="${root_dir}/build"
 install_dir="${root_dir}/install"
 
-mkdir $src_dir
-mkdir $bld_dir
-mkdir $install_dir
-mkdir $dl_dir
+mkdir ${src_dir}
+mkdir ${bld_dir}
+mkdir ${install_dir}
+mkdir ${dl_dir}
 
 # download all sources
 cd $dl_dir
@@ -52,13 +52,13 @@ tar -zxvf ${dl_dir}/"${gdb_base}.tar.gz"
 #
 # build binutils
 #
-cd $bld_dir
-mkdir $binutils_base
-cd $binutils_base
+cd ${bld_dir}
+mkdir ${binutils_base}
+cd ${binutils_base}
 ${src_dir}/${binutils_base}/configure --prefix=$PREFIX --target=$TARGET
 	--enable-interwork --enable-multilib --with-gnu-as --with-gnu-ld \
 	--disable-nls --disable-werror
-make
+make -j2 all
 make install
 
 #
@@ -73,8 +73,8 @@ cd ${gcc_base}-initial
 ${src_dir}/${gcc_base}/configure --prefix=$PREFIX --target=$TARGET \
         --with-gnu-as --with-gnu-ld --enable-languages=c,c++ \
         --with-newlib --without-headers 
-make
-make install
+make -j2 all-gcc
+make install-gcc
 
 # build libgcc.a
 make all-target-libgcc
@@ -83,20 +83,20 @@ make install-target-libgcc
 #
 # build newlib
 #
-cd $bld_dir
-mkdir $newlib_base
-cd $newlib_base
+cd ${bld_dir}
+mkdir ${newlib_base}
+cd ${newlib_base}
 ${src_dir}/${newlib_base}/configure --prefix=$PREFIX --target=$TARGET \
 	--disable-newlib-supplied-syscalls 
-make
+make -j2 all
 make install
 
 #
 # build GDB
 #
-cd $bld_dir
-mkdir $gdb_base
-cd $gdb_base
+cd ${bld_dir}
+mkdir ${gdb_base}
+cd ${gdb_base}
 ${src_dir}/${gdb_base}/configure --prefix=$PREFIX --target=$TARGET
-make
+make -j2 all
 make install

--- a/arm/build_arm_toolchain_7_1
+++ b/arm/build_arm_toolchain_7_1
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # in order to build the toolchain, we need some basic tools:
 # flex bison libgmp3-dev libmpfr-dev autoconf texinfo build-essential libncurses5-dev
@@ -10,6 +11,8 @@
 # gcc-7.1.0/bin). alternatively, the compiler may be left anywhere in the user
 # home directory.
 #
+
+set -o xtrace
 
 binutils_base="binutils-2.28"
 gcc_base="gcc-7.1.0"

--- a/arm/build_arm_toolchain_9_4
+++ b/arm/build_arm_toolchain_9_4
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # in order to build the toolchain, we need some basic tools:
 # flex bison libgmp3-dev libmpfr-dev autoconf texinfo build-essential libncurses5-dev
@@ -10,6 +11,8 @@
 # alternatively, the compiler may be left anywhere in the user home directory. Also, create
 # a symbolic link in the compiler directory (gcc-9.4.0 -> gcc) to support multiple
 # versions of the toolchain.
+
+set -o xtrace
 
 binutils_base="binutils-2.36.1"
 gcc_base="gcc-9.4.0"

--- a/avr/build_avr_toolchain_11_2
+++ b/avr/build_avr_toolchain_11_2
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # in order to build the toolchain, we need some basic tools:
 # flex bison libgmp3-dev libmpfr-dev autoconf texinfo build-essential libncurses5-dev
@@ -11,6 +12,8 @@
 # a symbolic link in the compiler directory (gcc-11.2.0 -> gcc) to support multiple
 # versions of the toolchain.
 #
+
+set -o xtrace
 
 binutils_base="binutils-2.37"
 gcc_base="gcc-11.2.0"

--- a/avr/build_avr_toolchain_9_4
+++ b/avr/build_avr_toolchain_9_4
@@ -63,13 +63,15 @@ make install
 #
 # build GCC
 #
+cd ${src_dir}/${gcc_base}/
+./contrib/download_prerequisites
 cd ${bld_dir}
 mkdir ${gcc_base}-initial
 cd ${gcc_base}-initial
 ${src_dir}/${gcc_base}/configure --prefix=$PREFIX --target=$TARGET \
 	--enable-languages=c,c++ --disable-nls --disable-libssp --with-dwarf2
-make
-make install
+make -j2 all-gcc
+make install-gcc
 
 #
 # build avr-libc
@@ -78,7 +80,7 @@ cd ${bld_dir}
 mkdir ${avrlibc_base}
 cd ${avrlibc_base}
 ${src_dir}/${avrlibc_base}/configure --build=`./config.guess` --host=$TARGET --prefix=$PREFIX
-make
+make -j2 all
 make install
 
 #
@@ -88,5 +90,5 @@ cd ${bld_dir}
 mkdir ${avrdude_base}
 cd ${avrdude_base}
 ${src_dir}/${avrdude_base}/configure --prefix=$PREFIX
-make
+make -j2 all
 make install

--- a/avr/build_avr_toolchain_9_4
+++ b/avr/build_avr_toolchain_9_4
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # in order to build the toolchain, we need some basic tools:
 # flex bison libgmp3-dev libmpfr-dev autoconf texinfo build-essential libncurses5-dev
@@ -11,6 +12,8 @@
 # a symbolic link in the compiler directory (gcc-9.4.0 -> gcc) to support multiple
 # versions of the toolchain.
 #
+
+set -o xtrace
 
 binutils_base="binutils-2.36.1"
 gcc_base="gcc-9.4.0"

--- a/avr/build_avr_toolchain_9_4
+++ b/avr/build_avr_toolchain_9_4
@@ -73,7 +73,7 @@ mkdir ${gcc_base}-initial
 cd ${gcc_base}-initial
 ${src_dir}/${gcc_base}/configure --prefix=$PREFIX --target=$TARGET \
 	--enable-languages=c,c++ --disable-nls --disable-libssp --with-dwarf2
-make -j2 all-gcc
+make -j2 all
 make install-gcc
 
 #

--- a/env.sh
+++ b/env.sh
@@ -8,18 +8,18 @@ TOOLCHAIN_PATH="./riscv32-unknown-elf/gcc-9.3.0/"
 export LANG="en_GB.UTF-8"
 
 # Pre-append path (binaries prefixed with arch name)
-export PATH="${TOOLCHAIN_PATH}/bin:${PATH}"
+export PATH="${TOOLCHAIN_PATH}/bin":${PATH}
 
-# Pre-append path (binaries without prefix overlapping system settings) 
-export PATH="${TOOLCHAIN_PATH}/riscv32-unknown-elf/bin:${PATH}"
+# Pre-append path (binaries without prefix overlapping system settings)
+export PATH="${TOOLCHAIN_PATH}/riscv32-unknown-elf/bin":${PATH}
 
 # Headers
-export C_INCLUDE_PATH="${TOOLCHAIN_PATH}/include:${C_INCLUDE_PATH}"
-export CPLUS_INCLUDE_PATH="${TOOLCHAIN_PATH}/include:${CPLUS_INCLUDE_PATH}"
+export C_INCLUDE_PATH="${TOOLCHAIN_PATH}/include":${C_INCLUDE_PATH}
+export CPLUS_INCLUDE_PATH="${TOOLCHAIN_PATH}/include":${CPLUS_INCLUDE_PATH}
 
 # Libraries
-export LIBRARY_PATH="${TOOLCHAIN_PATH}/lib:${LIBRARY_PATH}"
+export LIBRARY_PATH="${TOOLCHAIN_PATH}/lib":${LIBRARY_PATH}
 
 # Documentation
-prepend-path MANPATH "${BASE}/share/man"
-prepend-path INFOPATH "${BASE}/share/info"
+export MANPATH="${BASE}/share/man":${MANPATH}
+export INFOPATH="${BASE}/share/info":${INFOPATH}

--- a/env.sh
+++ b/env.sh
@@ -3,7 +3,8 @@
 # This is sample script to setup the environment.
 # Change the script changing the TOOLCHAIN_PATH accordingly
 
-TOOLCHAIN_PATH="./riscv32-unknown-elf/gcc-9.3.0/"
+TOOLCHAIN_PATH=$(dirname $(readlink -f $0))
+ARCH=$(basename $(dirname ${script_path}))
 
 export LANG="en_GB.UTF-8"
 
@@ -11,7 +12,7 @@ export LANG="en_GB.UTF-8"
 export PATH="${TOOLCHAIN_PATH}/bin":${PATH}
 
 # Pre-append path (binaries without prefix overlapping system settings)
-export PATH="${TOOLCHAIN_PATH}/riscv32-unknown-elf/bin":${PATH}
+export PATH="${TOOLCHAIN_PATH}/${ARCH}/bin":${PATH}
 
 # Headers
 export C_INCLUDE_PATH="${TOOLCHAIN_PATH}/include":${C_INCLUDE_PATH}

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+sudo apt-get update
+
+sudo apt-get install \
+    -y flex \
+    -y bison \
+    -y libgmp3-dev \
+    -y libmpfr-dev \
+    -y autoconf \
+    -y texinfo \
+    -y build-essential \
+    -y libncurses5-dev

--- a/mips/build_mips_toolchain_11_2_patched
+++ b/mips/build_mips_toolchain_11_2_patched
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # mods performed on GCC sources for the MIPS I target, enabled with the '-mips1' flag:
 # -no patented MIPS instructions are generated (swl, swr, lwl, lwr)
@@ -19,6 +20,8 @@
 # a symbolic link in the compiler directory (gcc-11.2.0 -> gcc) to support multiple
 # versions of the toolchain.
 #
+
+set -o xtrace
 
 binutils_base="binutils-2.37"
 gcc_base="gcc-11.2.0"

--- a/mips/build_mips_toolchain_4_9/build_mips_toolchain_4_9_patched
+++ b/mips/build_mips_toolchain_4_9/build_mips_toolchain_4_9_patched
@@ -66,10 +66,10 @@ src_dir="${root_dir}/source"
 bld_dir="${root_dir}/build"
 install_dir="${root_dir}/install"
 
-mkdir $src_dir
-mkdir $bld_dir
-mkdir $install_dir
-mkdir $dl_dir
+mkdir ${src_dir}
+mkdir ${bld_dir}
+mkdir ${install_dir}
+mkdir ${dl_dir}
 
 # download all sources
 cd $dl_dir
@@ -93,13 +93,13 @@ cp ${root_dir}/mips.opt ${src_dir}/${gcc_base}/gcc/config/mips/
 #
 # build binutils
 #
-cd $bld_dir
-mkdir $binutils_base
-cd $binutils_base
+cd ${bld_dir}
+mkdir ${binutils_base}
+cd ${binutils_base}
 ${src_dir}/${binutils_base}/configure --prefix=$PREFIX --target=$TARGET
 	--enable-interwork --enable-multilib --with-gnu-as --with-gnu-ld \
 	--disable-nls --disable-werror
-make
+make -j2 all
 make install
 
 #
@@ -114,8 +114,8 @@ cd ${gcc_base}-initial
 ${src_dir}/${gcc_base}/configure --prefix=$PREFIX --target=$TARGET \
         --with-gnu-as --with-gnu-ld --enable-languages=c \
         --with-newlib --without-headers 
-make
-make install
+make -j2
+make install-gcc
 
 # build libgcc.a
 make all-target-libgcc CFLAGS_FOR_TARGET="-g -O2 -mpatfree"
@@ -124,21 +124,21 @@ make install-target-libgcc
 #
 # build newlib
 #
-cd $bld_dir
-mkdir $newlib_base
-cd $newlib_base
+cd ${bld_dir}
+mkdir ${newlib_base}
+cd ${newlib_base}
 ${src_dir}/${newlib_base}/configure --prefix=$PREFIX --target=$TARGET \
 	--disable-newlib-supplied-syscalls CFLAGS_FOR_TARGET="-mpatfree"
-make
+make -j2
 make install
 
 #
 # build GDB
 #
-cd $bld_dir
-mkdir $gdb_base
-cd $gdb_base
+cd ${bld_dir}
+mkdir ${gdb_base}
+cd ${gdb_base}
 ${src_dir}/${gdb_base}/configure --prefix=$PREFIX --target=$TARGET
-make
+make -j2
 make install
 

--- a/mips/build_mips_toolchain_4_9/build_mips_toolchain_4_9_patched
+++ b/mips/build_mips_toolchain_4_9/build_mips_toolchain_4_9_patched
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # mods performed on GCC sources for the MIPS I target (new flags added):
 # -mpatfree - don't use patented MIPS instructions (swl, swr, lwl, lwr)
@@ -32,6 +32,8 @@
 #   next
 #   quit
 #
+
+set -o xtrace
 
 version() {
 	echo "$@" | gawk -F. '{ printf("%03d%03d%03d", $1,$2,$3); }'

--- a/mips/build_mips_toolchain_4_9/build_mips_toolchain_4_9_patched
+++ b/mips/build_mips_toolchain_4_9/build_mips_toolchain_4_9_patched
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 # this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # mods performed on GCC sources for the MIPS I target (new flags added):
@@ -31,6 +32,18 @@
 #   next
 #   quit
 #
+
+version() {
+	echo "$@" | gawk -F. '{ printf("%03d%03d%03d", $1,$2,$3); }'
+}
+
+FIRST_NOT_WORKING_VERSION=11.0.0
+gcc_version=$(gcc --version | head -n1 | cut -d" " -f4)
+
+if [ "$(version ${gcc_version})" -gt "$(version ${FIRST_NOT_WORKING_VERSION})" ]; then
+	echo "The $0 build requires a gcc (${gcc_version}) < ${FIRST_NOT_WORKING_VERSION}"
+	exit 1
+fi
 
 binutils_base="binutils-2.27"
 gcc_base="gcc-4.9.3"

--- a/mips/build_mips_toolchain_9_3
+++ b/mips/build_mips_toolchain_9_3
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # in order to build the toolchain, we need some basic tools:
 # flex bison libgmp3-dev libmpfr-dev autoconf texinfo build-essential libncurses5-dev
@@ -11,6 +12,8 @@
 # a symbolic link in the compiler directory (gcc-9.3.0 -> gcc) to support multiple
 # versions of the toolchain.
 #
+
+set -o xtrace
 
 binutils_base="binutils-2.36.1"
 gcc_base="gcc-9.3.0"

--- a/mips/build_mips_toolchain_9_3_patched
+++ b/mips/build_mips_toolchain_9_3_patched
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # mods performed on GCC sources for the MIPS I target, enabled with the '-mips1' flag:
 # -no patented MIPS instructions are generated (swl, swr, lwl, lwr)
@@ -19,6 +20,8 @@
 # a symbolic link in the compiler directory (gcc-9.3.0 -> gcc) to support multiple
 # versions of the toolchain.
 #
+
+set -o xtrace
 
 binutils_base="binutils-2.36.1"
 gcc_base="gcc-9.3.0"

--- a/riscv/build_riscv32_toolchain_11_2
+++ b/riscv/build_riscv32_toolchain_11_2
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # in order to build the toolchain, we need some basic tools:
 # flex bison libgmp3-dev libmpfr-dev autoconf texinfo build-essential libncurses5-dev
@@ -11,6 +12,8 @@
 # a symbolic link in the compiler directory (gcc-11.2.0 -> gcc) to support multiple
 # versions of the toolchain.
 #
+
+set -o xtrace
 
 binutils_base="binutils-2.37"
 gcc_base="gcc-11.2.0"

--- a/riscv/build_riscv32_toolchain_9_3
+++ b/riscv/build_riscv32_toolchain_9_3
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # in order to build the toolchain, we need some basic tools:
 # flex bison libgmp3-dev libmpfr-dev autoconf texinfo build-essential libncurses5-dev
@@ -11,6 +12,8 @@
 # a symbolic link in the compiler directory (gcc-9.3.0 -> gcc) to support multiple
 # versions of the toolchain.
 #
+
+set -o xtrace
 
 binutils_base="binutils-2.36.1"
 gcc_base="gcc-9.3.0"

--- a/riscv/build_riscv64_toolchain_11_2
+++ b/riscv/build_riscv64_toolchain_11_2
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # in order to build the toolchain, we need some basic tools:
 # flex bison libgmp3-dev libmpfr-dev autoconf texinfo build-essential libncurses5-dev
@@ -11,6 +12,8 @@
 # a symbolic link in the compiler directory (gcc-11.2.0 -> gcc) to support multiple
 # versions of the toolchain.
 #
+
+set -o xtrace
 
 binutils_base="binutils-2.37"
 gcc_base="gcc-11.2.0"

--- a/riscv/build_riscv64_toolchain_9_3
+++ b/riscv/build_riscv64_toolchain_9_3
@@ -1,5 +1,6 @@
 #!/bin/sh
-# this script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
+
+# This script was written by Sergio Johann Filho [sergio.johann@acad.pucrs.br]
 #
 # in order to build the toolchain, we need some basic tools:
 # flex bison libgmp3-dev libmpfr-dev autoconf texinfo build-essential libncurses5-dev
@@ -11,6 +12,8 @@
 # a symbolic link in the compiler directory (gcc-9.3.0 -> gcc) to support multiple
 # versions of the toolchain.
 #
+
+set -o xtrace
 
 binutils_base="binutils-2.36.1"
 gcc_base="gcc-9.3.0"


### PR DESCRIPTION
Hello, as we saw some toolchains were not working, then I improved them a bit.

- `arm-7.1` script was updated like the others, it is building again
- `avr-9.4` ./contrib/download_prerequisites were added, it is building too
- `mips-4.9_patched` i put a test to exit the build process if gcc is `11.0.0`. This can be adjusted if it is not right version to be skipped

Extra
- Fixed commands on `env.sh`
- Script to install dependencies
- Improved main Makefile organization
- A fixed env.sh is added to the build folder
- Logging commands on build.log too instead of just the output of them (easier to understand what is happening)